### PR TITLE
 Add Pagination Support to Events API

### DIFF
--- a/controllers/eventController.js
+++ b/controllers/eventController.js
@@ -48,3 +48,23 @@ export const deleteEvent = async (req, res) => {
         res.status(500).json({ message: 'Error deleting event', error: err });
       }
 };
+
+export const getPaginatedEvents = async (req, res) => {
+  try {
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 6;
+    const skip = (page - 1) * limit;
+
+    const events = await Event.find().skip(skip).limit(limit);
+    const total = await Event.countDocuments();
+
+    res.json({
+      page,
+      totalPages: Math.ceil(total / limit),
+      totalEvents: total,
+      events
+    });
+  } catch (err) {
+    res.status(500).json({ message: 'Error fetching paginated events', error: err.message });
+  }
+};

--- a/routes/eventRoutes.js
+++ b/routes/eventRoutes.js
@@ -1,8 +1,10 @@
 import express from 'express';
 
-import { getEvent, addEvent, editEvent, deleteEvent } from '../controllers/eventController.js';
+import { getEvent, addEvent, editEvent, deleteEvent,getPaginatedEvents } from '../controllers/eventController.js';
 
 const router = express.Router();
+
+router.get('/paginated', getPaginatedEvents);
 
 router.get('/', getEvent);
 
@@ -11,5 +13,6 @@ router.post('/', addEvent);
 router.put('/:id', editEvent);
 
 router.delete('/:id', deleteEvent);
+
 
 export default router;

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import mongoose from 'mongoose';
 import cors from 'cors';
-import bodyParser from 'body-parser';
+import dotenv from 'dotenv';
 
 // Import Models
 import Timeline_events from './models/Timeline_Events.js';
@@ -11,42 +11,41 @@ import eventRoutes from './routes/eventRoutes.js';
 import projectRoutes from './routes/projectRoutes.js';
 import membersRoutes from './routes/membersRoutes.js';
 import timelineRoutes from './routes/timelineRoutes.js';
-  
+
+// Config
+dotenv.config();
 const app = express();
-const PORT = 5000;
+const PORT = process.env.PORT || 5000;
 
 // Middleware
 app.use(cors());
-app.use(bodyParser.json());
+app.use(express.json()); 
 
 // MongoDB Connection
-mongoose.connect('mongodb+srv://inteliot:inteliot@backend.ipiryxk.mongodb.net/intel-iot-club')
-.then(() => console.log('✅ MongoDB connected'))
-.catch((err) => console.error('❌ MongoDB connection error:', err));
+mongoose.connect(process.env.MONGO_URI)
+.then(() => console.log('MongoDB connected'))
+.catch((err) => console.error('MongoDB connection error:', err));
+
+// Root Health Check
+app.get('/', (req, res) => {
+  res.send('Backend API is live!');
+});
 
 /* ROUTES */
-
-// Events
 app.use('/api/events', eventRoutes);
-
-// Projects
 app.use('/api/projects', projectRoutes);
-
-// Members
 app.use('/api/members', membersRoutes);
-
-// Timeline Events
 app.use('/api/timeline', timelineRoutes);
 
-app.get("/api/timeline_events/get", async (req, res) => {
+// Special Timeline Get
+app.get("/api/timeline-events", async (req, res) => {
   try {
-    const events = await Timeline_events.find().sort({ date: 1 }); // sorted by date ascending
+    const events = await Timeline_events.find().sort({ date: 1 });
     res.json(events);
   } catch (err) {
     res.status(500).json({ message: 'Error fetching timeline events', error: err.message });
   }
 });
-
 
 // Start server
 app.listen(PORT, () => {

--- a/server.js
+++ b/server.js
@@ -22,9 +22,9 @@ app.use(cors());
 app.use(express.json()); 
 
 // MongoDB Connection
-mongoose.connect(process.env.MONGO_URI)
-.then(() => console.log('MongoDB connected'))
-.catch((err) => console.error('MongoDB connection error:', err));
+mongoose.connect('mongodb+srv://inteliot:inteliot@backend.ipiryxk.mongodb.net/intel-iot-club')
+.then(() => console.log('✅ MongoDB connected'))
+.catch((err) => console.error('❌ MongoDB connection error:', err));
 
 // Root Health Check
 app.get('/', (req, res) => {


### PR DESCRIPTION
 What’s Added
Introduced a new controller method: getPaginatedEvents

Added a new route: GET /api/events/paginated?page=1&limit=6

Supports dynamic pagination using query parameters:

page: current page number (default: 1)

limit: number of events per page (default: 6)

Returns:

page: current page

totalPages: total number of pages

totalEvents: total number of event documents

events: array of event data for that page

📁 Files Modified
controllers/eventController.js: Added getPaginatedEvents method

routes/eventRoutes.js: Added /paginated route (moved above / route to avoid conflict)