### PR TITLE
Add event sorting by latest date 

### DIFF
--- a/controllers/eventController.js
+++ b/controllers/eventController.js
@@ -3,7 +3,7 @@ import Event from '../models/Event.js';
 // Get all events
 export const getEvent = async (req, res) => {
     try {
-        const events = await Event.find();
+        const events = await Event.find().sort({ date: -1 }); // ← sort by date DESCENDING
         if(!events || events.length === 0) {
           return res.status(404).json({ message: 'No events found' });}
         res.status(200).json(events);


### PR DESCRIPTION
This PR updates the `getEvent` controller to return all events sorted by date in descending order (i.e., newest events appear first).

 Changes Made
- Modified the `Event.find()` query to include `.sort({ date: -1 })` for latest-to-oldest ordering.
- No changes were made to API routes or frontend-breaking changes.

 Why This Change?
- Improves user experience by displaying the most recent events at the top.
- Keeps the event listing relevant and timely.

 Notes
- The `date` field is a string in `YYYY-MM-DD` format, so it sorts lexicographically as expected.